### PR TITLE
modify columns of `tokenize_to_df` output

### DIFF
--- a/R/form.R
+++ b/R/form.R
@@ -13,55 +13,75 @@
 #' @export
 form <- function(x, mode, type, pos = TRUE) {
   type <-
-    rlang::arg_match(type,
-                     c("surface",
-                       "dictionary",
-                       "normalized",
-                       "reading",
-                       "part_of_speech"))
+    rlang::arg_match(
+      type,
+      c(
+        "surface",
+        "dictionary",
+        "normalized",
+        "reading",
+        "part_of_speech"
+      )
+    )
   fn <-
-    switch (type,
-            "surface" = "surface",
-            "dictionary" = "dictionary_form",
-            "normalized" = "normalized_form",
-            "reading" = "reading_form",
-            "part_of_speech" = "part_of_speech")
+    switch(type,
+      "surface" = "surface",
+      "dictionary" = "dictionary_form",
+      "normalized" = "normalized_form",
+      "reading" = "reading_form",
+      "part_of_speech" = "part_of_speech"
+    )
   purrr::map(tokenizer(x, mode),
-             form_vec,
-             type = fn,
-             pos = pos)
+    form_vec,
+    type = fn,
+    pos = pos
+  )
 }
 
 form_vec <- function(x, type, pos = TRUE) {
   type <-
-    rlang::arg_match(type,
-                     c("surface",
-                       "dictionary_form",
-                       "normalized_form",
-                       "reading_form",
-                       "part_of_speech"))
+    rlang::arg_match(
+      type,
+      c(
+        "surface",
+        "dictionary_form",
+        "normalized_form",
+        "reading_form",
+        "part_of_speech"
+      )
+    )
   if (type != "part_of_speech") {
     res <-
-      purrr::map_chr(seq.int(reticulate::py_len(x)),
-                     ~ purrr::pluck(x[.x - 1],
-                                    type) %>% {
-                                      .()
-                                    })
+      purrr::map_chr(
+        seq.int(reticulate::py_len(x)),
+        ~ purrr::pluck(
+          x[.x - 1],
+          type
+        ) %>% {
+          .()
+        }
+      )
     if (pos == TRUE) {
       res <-
         purrr::set_names(
-        res,
-        purrr::map_chr(
-          seq.int(reticulate::py_len(x)),
-          ~ x[.x - 1]$part_of_speech()[1]))
+          res,
+          purrr::map_chr(
+            seq.int(reticulate::py_len(x)),
+            ~ x[.x - 1]$part_of_speech()[1]
+          )
+        )
     }
   } else {
     res <-
-      purrr::map(seq.int(reticulate::py_len(x)),
-                 ~ purrr::pluck(x[.x - 1],
-                                type) %>% {
-                                  .()
-                                })
+      purrr::map(
+        seq.int(reticulate::py_len(x)),
+        ~ purrr::pluck(
+          x[.x - 1],
+          type
+        ) %>% {
+          .()
+        }
+      )
   }
   res
 }

--- a/R/install.R
+++ b/R/install.R
@@ -3,13 +3,18 @@
 #' for installing the SudachiPy It requires version 3.5 or higher.
 create_sudachipy_env <- function(python_version = 3.9) {
   if (sum(grepl("r-sudachipy", reticulate::conda_list()$name)) == 0) {
-    if (python_version < 3.5)
+    if (python_version < 3.5) {
       rlang::abort("SudachiPy requirements for python 3.5 or higher.")
+    }
     packages <-
       c(paste("python",
-              python_version, sep = "="))
-    reticulate::conda_create(envname = "r-sudachipy",
-                             packages = packages)
+        python_version,
+        sep = "="
+      ))
+    reticulate::conda_create(
+      envname = "r-sudachipy",
+      packages = packages
+    )
   } else {
     rlang::inform(cli::col_green("r-sudachipy already exist."))
   }
@@ -33,15 +38,23 @@ install_sudachipy <- function() {
   sudachipy_version <-
     c(
       paste0("sudachipy", "==", "0.4.9"),
-      "sudachidict_core") # nolint use latest dictionary
-  reticulate::conda_install(envname = "r-sudachipy",
-                            packages = sudachipy_version,
-                            pip = TRUE)
-  cat(cli::col_green('\nInstallation complete.\n'),
-      cli::col_grey('Restarte to R, activate environment with `',
-                    cli::style_bold('reticulate::use_condaenv(condaenv = "r-sudachipy", required = TRUE)')))
-  if (rstudioapi::hasFun("restartSession"))
+      "sudachidict_core"
+    ) # nolint use latest dictionary
+  reticulate::conda_install(
+    envname = "r-sudachipy",
+    packages = sudachipy_version,
+    pip = TRUE
+  )
+  cat(
+    cli::col_green("\nInstallation complete.\n"),
+    cli::col_grey(
+      "Restarte to R, activate environment with `",
+      cli::style_bold('reticulate::use_condaenv(condaenv = "r-sudachipy", required = TRUE)')
+    )
+  )
+  if (rstudioapi::hasFun("restartSession")) {
     rstudioapi::restartSession()
+  }
   invisible(NULL)
 }
 
@@ -55,6 +68,8 @@ install_sudachipy <- function() {
 #' }
 #' @export
 remove_sudachipy <- function() {
-  reticulate::conda_remove(envname = "r-sudachipy",
-                           packages = "sudachipy")
+  reticulate::conda_remove(
+    envname = "r-sudachipy",
+    packages = "sudachipy"
+  )
 }

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -68,19 +68,21 @@ tokenizer <- function(x, mode, instance = NULL) {
 #' }
 #' @export
 tokenize_to_df <- function(x, mode, instance = NULL) {
-  purrr::map_dfr(
+  purrr::imap_dfr(
     tokenizer(x, mode = mode, instance = instance),
-    ~ tokenize_to_df_vec(.x),
-    .id = "id")
+    ~ tokenize_to_df_vec(.x, .y)
+  )
 }
 
-tokenize_to_df_vec <- function(m) {
+tokenize_to_df_vec <- function(m, i) {
   dplyr::bind_cols(
-    purrr::map_dfr(seq.int(reticulate::py_len(m)), ~
-                     tibble::tibble(surface = m[. - 1]$surface(),
-                                    dic_form = m[. - 1]$dictionary_form(),
-                                    normalized_form = m[. - 1]$normalized_form(),
-                                    reading = m[. - 1]$reading_form())),
+    tibble::tibble(id = i),
+    purrr::imap_dfr(seq.int(reticulate::py_len(m)), ~
+                     tibble::tibble(token_id = .y,
+                                    surface = m[.x - 1]$surface(),
+                                    dic_form = m[.x - 1]$dictionary_form(),
+                                    normalized_form = m[.x - 1]$normalized_form(),
+                                    reading = m[.x - 1]$reading_form())),
     purrr::map_dfr(
       seq.int(reticulate::py_len(m)),
       ~ purrr::map_dfr(purrr::set_names(

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -34,28 +34,40 @@ tokenizer <- function(x, mode, instance = NULL) {
     instance <-
       rebuild_tokenizer()
   } else {
-    if (!identical(class(instance),
-                  c("sudachipy.tokenizer.Tokenizer", "python.builtin.object")))
-      rlang::abort(paste0("Please, set ",
-                          cli::style_bold("<sudachipy.tokenizer.Tokenizer>"),
-                          "class object"))
+    if (!identical(
+      class(instance),
+      c("sudachipy.tokenizer.Tokenizer", "python.builtin.object")
+    )) {
+      rlang::abort(paste0(
+        "Please, set ",
+        cli::style_bold("<sudachipy.tokenizer.Tokenizer>"),
+        "class object"
+      ))
+    }
   }
   mode <-
-    switch (mode,
-            "A" = instance$SplitMode$A,
-            "B" = instance$SplitMode$B,
-            "C" = instance$SplitMode$C)
+    switch(mode,
+      "A" = instance$SplitMode$A,
+      "B" = instance$SplitMode$B,
+      "C" = instance$SplitMode$C
+    )
   res <-
-    purrr::map(x,
-               ~ instance$tokenize(.x, mode))
+    purrr::map(
+      x,
+      ~ instance$tokenize(.x, mode)
+    )
   purrr::map(
     res,
     ~ cat(cli::col_cyan(
       glue::glue("Parsed to {n} {token}\n\n",
-                 n = reticulate::py_len(.x),
-                 token = ifelse(reticulate::py_len(.x) > 1L,
-                                          "tokens",
-                                          "token")))))
+        n = reticulate::py_len(.x),
+        token = ifelse(reticulate::py_len(.x) > 1L,
+          "tokens",
+          "token"
+        )
+      )
+    ))
+  )
   res
 }
 
@@ -77,22 +89,36 @@ tokenize_to_df <- function(x, mode, instance = NULL) {
 tokenize_to_df_vec <- function(m, i) {
   dplyr::bind_cols(
     tibble::tibble(id = i),
-    purrr::imap_dfr(seq.int(reticulate::py_len(m)), ~
-                     tibble::tibble(token_id = .y,
-                                    surface = m[.x - 1]$surface(),
-                                    dic_form = m[.x - 1]$dictionary_form(),
-                                    normalized_form = m[.x - 1]$normalized_form(),
-                                    reading = m[.x - 1]$reading_form())),
+    purrr::imap_dfr(
+      seq.int(reticulate::py_len(m)),
+      ~ tibble::tibble(
+        token_id = .y,
+        surface = m[.x - 1]$surface(),
+        dic_form = m[.x - 1]$dictionary_form(),
+        normalized_form = m[.x - 1]$normalized_form(),
+        reading = m[.x - 1]$reading_form()
+      )
+    ),
     purrr::map_dfr(
       seq.int(reticulate::py_len(m)),
       ~ purrr::map_dfr(purrr::set_names(
         as.data.frame(
           t(
-            data.frame(x = m[.x - 1]$part_of_speech()))),
-        c(paste0(intToUtf8(c(21697, 35422)),
-                 seq_len(4)),
+            data.frame(x = m[.x - 1]$part_of_speech())
+          )
+        ),
+        c(
+          paste0(
+            intToUtf8(c(21697, 35422)),
+            seq_len(4)
+          ),
           intToUtf8(c(27963, 29992, 22411)),
-          intToUtf8(c(27963, 29992, 24418)))),
-        dplyr::na_if,
-        y = "*")))
+          intToUtf8(c(27963, 29992, 24418))
+        )
+      ),
+      dplyr::na_if,
+      y = "*"
+      )
+    )
+  )
 }

--- a/tests/testthat/test-tokenize.R
+++ b/tests/testthat/test-tokenize.R
@@ -6,8 +6,10 @@ test_that("tokenize", {
   skip_if_no_sudachi()
   res <-
     tokenizer("Tokyo, Japan", mode = "A")
-  expect_length(res,
-                1L)
+  expect_length(
+    res,
+    1L
+  )
   expect_output(
     tokenizer("Tokyo, Japan", mode = "A"),
     "Parsed to 4 tokens"

--- a/tests/testthat/utils.R
+++ b/tests/testthat/utils.R
@@ -1,4 +1,5 @@
 skip_if_no_sudachi <- function() {
-  if (!reticulate::py_module_available("sudachipy"))
+  if (!reticulate::py_module_available("sudachipy")) {
     skip("SudachiPy not available for testing")
+  }
 }


### PR DESCRIPTION
次の3点を変更するPRです。

1. `tokenize_to_df`の戻り値の`id`列がchr型になっているのをintegerに変える
2. `tokenize_to_df`の戻り値に`token_id`列を追加
3. ソースコードのフォーマット（`usethis::use_tidy_style`）

戻り値のデータフレームは以下のようになります。

### Before

![image](https://user-images.githubusercontent.com/33294906/104869291-07221d80-5989-11eb-9068-f4c909825f84.png)

### After

![image](https://user-images.githubusercontent.com/33294906/104869442-6a13b480-5989-11eb-9a7f-241157224ac6.png)

3については好みもあると思うので、1と2はいいけど3は元に戻してほしい場合、その旨コメントしてください。ひとつ前のコミットから再度PRを出します。
